### PR TITLE
WIP - Avoid java 7 compilation problems

### DIFF
--- a/impl/imap-mailbox/pom.xml
+++ b/impl/imap-mailbox/pom.xml
@@ -39,7 +39,6 @@
         <module>core</module>
         <module>cassandra</module>
         <module>cyrus</module>
-        <module>elasticsearch</module>
         <module>external-james</module>
         <module>hbase</module>
         <module>inmemory</module>


### PR DESCRIPTION
Some commit to avoid compiling ElasticSearch and Tika must be removed.
